### PR TITLE
Use num_cpus to get number of threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ include = [
 
 [dependencies]
 rand = "0.6.1"
+num_cpus = "1.0"
 
 [badges]
 maintenance = { status = "as-is" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use rand::{Rng, FromEntropy};
 use rand::rngs::SmallRng;
 
+extern crate num_cpus;
 // Naive port of http://fabiensanglard.net/postcard_pathtracer/ from C/C++ to Rust
 
 #[derive(Debug, Copy, Clone)]
@@ -342,7 +343,7 @@ fn main() -> std::io::Result<()> {
     // Write the image header
     print!("P6 {} {} 255 ", width, height);
     
-    let num_threads : i32 = 4;
+    let num_threads : i32 = num_cpus::get() as i32;
     let mut thread_handles = Vec::with_capacity(num_threads as usize);
     let height_block = (height + num_threads - 1) / num_threads;
     for n in 0..num_threads {


### PR DESCRIPTION
Use the num_cpus crate to spawn a number of threads that is in line with the number of available cpus.